### PR TITLE
Fetch accurate floating-point values from SQLite

### DIFF
--- a/lib/GnuCash/SQLite.pm
+++ b/lib/GnuCash/SQLite.pm
@@ -133,7 +133,7 @@ sub _node_bal {
     my $self = shift;
     my $guid = shift;
 
-    my $sql = "SELECT SUM(value_num/(value_denom*1.0)) FROM splits "
+    my $sql = "SELECT printf('%.2f',SUM(value_num/(value_denom*1.0))) FROM splits "
             . "WHERE account_guid = ?";
     return $self->_runsql($sql,$guid)->[0][0] || 0;
 }

--- a/t/GnuCash-SQLite.t
+++ b/t/GnuCash-SQLite.t
@@ -81,7 +81,7 @@ tt('child_guid() returns empty list for leaf accounts.',
 
 $guid = $reader->account_guid('Assets:Cash');
 tt('_node_bal() returns correct balance.',
-    got => $reader->_node_bal($guid),
+    got => $reader->_node_bal($guid)+0,
     exp => 10000);
 
 $guid = $reader->account_guid('Assets:Cash');


### PR DESCRIPTION
The Perl module is fetching from SQLite the numerical value of an account/sub-account, but the numbers are rounded instead of being accurate.

I found a bit of information on it here:

https://dba.stackexchange.com/questions/62491/why-does-sqlite-return-incorrect-sum

In any case, this use of `printf` allows fetching the correct data. I verified this on "production" data of my own financial accounts. :)

A test was updated, but no particular test was added for this. The test was updated because the comparison was a string (which now included two decimal digits) instead of a numeric comparison.